### PR TITLE
Increase procfs content cache duration to 1000ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A set of additional JVM process metrics for [micrometer.io](https://micrometer.i
     new ProcessMemoryMetrics().bindTo(registry);
     new ProcessThreadMetrics().bindTo(registry);
 ```
+
 ```java
     /* With Spring */
     @Bean
@@ -48,10 +49,11 @@ A set of additional JVM process metrics for [micrometer.io](https://micrometer.i
 
 `ProcessMemoryMetrics` reads process-level memory information from `/proc/self/smaps`.
 All `Meter`s are reporting in `bytes`.
-Please note that `procfs` is only available on Linux-based systems.
+
+> Please note that `procfs` is only available on Linux-based systems.
 
 * `process.memory.vss`: Virtual set size. The amount of virtual memory the process can access.
-   Mostly useles, but included for completeness sake.
+  Mostly useles, but included for completeness sake.
 * `process.memory.rss`: Resident set size. The amount of process memory currently in RAM.
 * `process.memory.pss`: Proportional set size. The amount of process memory currently in RAM,
   accounting for shared pages among processes. This metric is the most accurate in
@@ -64,11 +66,13 @@ Please note that `procfs` is only available on Linux-based systems.
 ### ProcessThreadMetrics
 
 `ProcessThreadMetrics` reads process-level thread information from `/proc/self/status`.
-Please note that `procfs` is only available on Linux-based systems.
+
+> Please note that `procfs` is only available on Linux-based systems.
 
 * `process.threads`: The number of process threads as seen by the operating system.
 
 ## Notes
-* procfs data is cached for `100ms` in order to relief the filesystem pressure
+
+* procfs data is cached for `1000ms` in order to relief the filesystem pressure
   when `Meter`s based on this data are queried by the registry one after
   another on collection run.

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsReader.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsReader.java
@@ -26,7 +26,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class ProcfsReader {
+
+    private static final Logger log = LoggerFactory.getLogger(ProcfsReader.class);
 
     private static final Map<String, ProcfsReader> instances = new HashMap<>();
 
@@ -38,7 +43,7 @@ class ProcfsReader {
 
     private static final Path BASE = Paths.get("/proc", "self");
 
-    /* default */ static final long CACHE_DURATION_MS = 100;
+    /* default */ static final long CACHE_DURATION_MS = 1000;
 
     /* default */ long lastReadTime = -1;
 
@@ -95,6 +100,11 @@ class ProcfsReader {
         if (!osSupport) {
             return Collections.emptyList();
         }
+
+        if (log.isTraceEnabled()) {
+            log.trace("Reading '" + path + "'");
+        }
+
         return Files.readAllLines(path);
     }
 


### PR DESCRIPTION
It's not guaranteed that Meters are being collected in ordered
lexicographic fashion and hitting the former 100ms caching limit
is reproducable easily in a low performance environment.