### PR TITLE
smaps+status: improve line matching performance (+JMH benchmarks)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 
     <properties>
         <slf4j.version>1.7.26</slf4j.version>
+        <jmh.version>1.21</jmh.version>
 
         <!-- Pull up versions for Java 11 compatibility. -->
         <dep.plugin.surefire.version>2.22.1</dep.plugin.surefire.version>
@@ -82,6 +83,18 @@
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -91,6 +104,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <configuration>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <excludes>**/*_jmh*.java</excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -98,6 +112,7 @@
                 <configuration>
                     <printFailingErrors>true</printFailingErrors>
                     <includeTests>true</includeTests>
+                    <excludes>**/*_jmh*.java</excludes>
                     <rulesets>
                         <ruleset>src/build/resources/pmd-ruleset.xml</ruleset>
                     </rulesets>
@@ -126,6 +141,21 @@
                         <exclude>src/build/resources/**/*.*</exclude>
                         <exclude>src/test/resources/**/*.*</exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Help Eclipse processing the JMH benchmarks. -->
+                    <!-- (Otherwise META-INF/BenchmarkList is not generated.) -->
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsSmaps.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsSmaps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2016-2019 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ProcfsSmaps extends ProcfsEntry {
 
@@ -44,6 +46,8 @@ public class ProcfsSmaps extends ProcfsEntry {
          */
         SWAPPSS
     }
+
+    private static final Pattern LINE_PATTERN = Pattern.compile("^\\w+:\\s+(\\d+)\\skB$");
 
     private static final int KILOBYTE = 1024;
 
@@ -88,7 +92,12 @@ public class ProcfsSmaps extends ProcfsEntry {
     private static Double parseKiloBytes(String line) {
         Objects.requireNonNull(line);
 
-        return Double.parseDouble(line.split("\\s+")[1]);
+        final Matcher matcher = LINE_PATTERN.matcher(line);
+        if (!matcher.matches()) {
+            return Double.NaN;
+        }
+
+        return Double.parseDouble(matcher.group(1));
     }
 
 }

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatus.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2019 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ProcfsStatus extends ProcfsEntry {
 
@@ -28,6 +30,8 @@ public class ProcfsStatus extends ProcfsEntry {
          */
         THREADS
     }
+
+    private static final Pattern LINE_PATTERN = Pattern.compile("^\\w+:\\s+(\\d+)$");
 
     public ProcfsStatus() {
         super(ProcfsReader.getInstance("status"));
@@ -55,7 +59,12 @@ public class ProcfsStatus extends ProcfsEntry {
     private static Double parseValue(String line) {
         Objects.requireNonNull(line);
 
-        return Double.parseDouble(line.split("\\s+")[1]);
+        final Matcher matcher = LINE_PATTERN.matcher(line);
+        if (!matcher.matches()) {
+            return Double.NaN;
+        }
+
+        return Double.parseDouble(matcher.group(1));
     }
 
 }

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsSmapsBenchmark.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsSmapsBenchmark.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2019 Michael Weirauch (michael.weirauch@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.mweirauch.micrometer.jvm.extras.procfs;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class ProcfsSmapsBenchmark {
+
+    private ProcfsSmaps uub;
+
+    public static void main(String[] args) throws RunnerException {
+        final Options options = new OptionsBuilder() //
+                .include(ProcfsSmapsBenchmark.class.getSimpleName()) //
+                .addProfiler(GCProfiler.class) //
+                .build();
+
+        new Runner(options).run();
+    }
+
+    @Setup
+    public void setup() throws URISyntaxException {
+        final ProcfsReader reader = new ProcfsReader(
+                Paths.get(ProcfsSmapsBenchmark.class.getResource("/procfs/").toURI()),
+                "smaps-002.txt");
+        uub = new ProcfsSmaps(reader);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SingleShotTime)
+    @Fork(value = 5, warmups = 0)
+    public void collectSingle() {
+        uub.collect();
+    }
+
+}

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusBenchmark.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusBenchmark.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2019 Michael Weirauch (michael.weirauch@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.mweirauch.micrometer.jvm.extras.procfs;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class ProcfsStatusBenchmark {
+
+    private ProcfsStatus uub;
+
+    public static void main(String[] args) throws RunnerException {
+        final Options options = new OptionsBuilder() //
+                .include(ProcfsStatusBenchmark.class.getSimpleName()) //
+                .addProfiler(GCProfiler.class) //
+                .build();
+
+        new Runner(options).run();
+    }
+
+    @Setup
+    public void setup() throws URISyntaxException {
+        final ProcfsReader reader = new ProcfsReader(
+                Paths.get(ProcfsStatusBenchmark.class.getResource("/procfs/").toURI()),
+                "status-001.txt");
+        uub = new ProcfsStatus(reader);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SingleShotTime)
+    @Fork(value = 5, warmups = 0)
+    public void collectSingle() {
+        uub.collect();
+    }
+
+}


### PR DESCRIPTION
Caching the line pattern saves some CPU cycles and allocations,
though the big memory hog is still the caching of file contents.

smaps before/after:
```
Benchmark                                               Mode  Cnt        Score    Error   Units
ProcfsSmapsBenchmark.collectSingle                        ss    5       27,884 ±  8,599   ms/op
ProcfsSmapsBenchmark.collectSingle:·gc.alloc.rate         ss    5        5,404 ±  0,108  MB/sec
ProcfsSmapsBenchmark.collectSingle:·gc.alloc.rate.norm    ss    5  3190144,000 ± 87,130    B/op
ProcfsSmapsBenchmark.collectSingle:·gc.count              ss    5          ≈ 0           counts

Benchmark                                               Mode  Cnt        Score      Error   Units
ProcfsSmapsBenchmark.collectSingle                        ss    5       15,372 ±    6,415   ms/op
ProcfsSmapsBenchmark.collectSingle:·gc.alloc.rate         ss    5        4,479 ±    0,127  MB/sec
ProcfsSmapsBenchmark.collectSingle:·gc.alloc.rate.norm    ss    5  2597443,200 ± 1931,854    B/op
ProcfsSmapsBenchmark.collectSingle:·gc.count              ss    5          ≈ 0             counts
```
status before/after:
```
Benchmark                                                Mode  Cnt        Score      Error   Units
ProcfsStatusBenchmark.collectSingle                        ss    5        6,423 ±    1,917   ms/op
ProcfsStatusBenchmark.collectSingle:·gc.alloc.rate         ss    5        2,374 ±    0,053  MB/sec
ProcfsStatusBenchmark.collectSingle:·gc.alloc.rate.norm    ss    5  1316771,200 ± 1611,848    B/op
ProcfsStatusBenchmark.collectSingle:·gc.count              ss    5          ≈ 0             counts

Benchmark                                                Mode  Cnt        Score      Error   Units
ProcfsStatusBenchmark.collectSingle                        ss    5        5,611 ±    1,384   ms/op
ProcfsStatusBenchmark.collectSingle:·gc.alloc.rate         ss    5        2,395 ±    0,026  MB/sec
ProcfsStatusBenchmark.collectSingle:·gc.alloc.rate.norm    ss    5  1319366,400 ± 1974,103    B/op
ProcfsStatusBenchmark.collectSingle:·gc.count              ss    5          ≈ 0             counts
```