### PR TITLE
procfs: drop caching of read lines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,4 +163,17 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <!-- false-positive: https://github.com/spotbugs/spotbugs/issues/756 -->
+            <id>spotbugs-jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <properties>
+                <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsSmaps.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsSmaps.java
@@ -15,8 +15,6 @@
  */
 package io.github.mweirauch.micrometer.jvm.extras.procfs;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -60,33 +58,28 @@ public class ProcfsSmaps extends ProcfsEntry {
     }
 
     @Override
-    protected Map<ValueKey, Double> handle(Collection<String> lines) {
-        Objects.requireNonNull(lines);
+    protected void handle(Map<ValueKey, Double> values, String line) {
+        Objects.requireNonNull(values);
+        Objects.requireNonNull(line);
 
-        final Map<ValueKey, Double> values = new HashMap<>();
-
-        for (final String line : lines) {
-            KEY valueKey = null;
-            if (line.startsWith("Size:")) {
-                valueKey = KEY.VSS;
-            } else if (line.startsWith("Rss:")) {
-                valueKey = KEY.RSS;
-            } else if (line.startsWith("Pss:")) {
-                valueKey = KEY.PSS;
-            } else if (line.startsWith("Swap:")) {
-                valueKey = KEY.SWAP;
-            } else if (line.startsWith("SwapPss:")) {
-                valueKey = KEY.SWAPPSS;
-            }
-
-            if (valueKey != null) {
-                final Double kiloBytes = parseKiloBytes(line) * KILOBYTE;
-                values.compute(valueKey, (key, value) -> (value == null) ? kiloBytes
-                        : value.doubleValue() + kiloBytes);
-            }
+        KEY valueKey = null;
+        if (line.startsWith("Size:")) {
+            valueKey = KEY.VSS;
+        } else if (line.startsWith("Rss:")) {
+            valueKey = KEY.RSS;
+        } else if (line.startsWith("Pss:")) {
+            valueKey = KEY.PSS;
+        } else if (line.startsWith("Swap:")) {
+            valueKey = KEY.SWAP;
+        } else if (line.startsWith("SwapPss:")) {
+            valueKey = KEY.SWAPPSS;
         }
 
-        return values;
+        if (valueKey != null) {
+            final Double kiloBytes = parseKiloBytes(line) * KILOBYTE;
+            values.compute(valueKey,
+                    (key, value) -> (value == null) ? kiloBytes : value.doubleValue() + kiloBytes);
+        }
     }
 
     private static Double parseKiloBytes(String line) {

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatus.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatus.java
@@ -15,8 +15,6 @@
  */
 package io.github.mweirauch.micrometer.jvm.extras.procfs;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -42,18 +40,13 @@ public class ProcfsStatus extends ProcfsEntry {
     }
 
     @Override
-    protected Map<ValueKey, Double> handle(Collection<String> lines) {
-        Objects.requireNonNull(lines);
+    protected void handle(Map<ValueKey, Double> values, String line) {
+        Objects.requireNonNull(values);
+        Objects.requireNonNull(line);
 
-        final Map<ValueKey, Double> values = new HashMap<>();
-
-        for (final String line : lines) {
-            if (line.startsWith("Threads:")) {
-                values.put(KEY.THREADS, parseValue(line));
-            }
+        if (line.startsWith("Threads:")) {
+            values.put(KEY.THREADS, parseValue(line));
         }
-
-        return values;
     }
 
     private static Double parseValue(String line) {

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsSmapsTest.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsSmapsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2016-2019 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 package io.github.mweirauch.micrometer.jvm.extras.procfs;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -83,7 +84,7 @@ public class ProcfsSmapsTest {
     @Test
     public void testReturnDefaultValuesOnReaderFailure() throws IOException {
         final ProcfsReader reader = mock(ProcfsReader.class);
-        when(reader.read()).thenThrow(new IOException("THROW"));
+        doThrow(new IOException("fail")).when(reader).read(any());
 
         final ProcfsSmaps uut = new ProcfsSmaps(reader);
 

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusTest.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2019 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 package io.github.mweirauch.micrometer.jvm.extras.procfs;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -68,7 +69,7 @@ public class ProcfsStatusTest {
     @Test
     public void testReturnDefaultValuesOnReaderFailure() throws IOException {
         final ProcfsReader reader = mock(ProcfsReader.class);
-        when(reader.read()).thenThrow(new IOException("THROW"));
+        doThrow(new IOException("fail")).when(reader).read(any());
 
         final ProcfsStatus uut = new ProcfsStatus(reader);
 


### PR DESCRIPTION
Re-reading is now limited to 1000ms in the ProcfsEntry instead of
ProcfsReader itself.