### PR TITLE
Drop support for proportional set size metrics (pss, swappss)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,26 @@ A set of additional JVM process metrics for [micrometer.io](https://micrometer.i
 
 ### ProcessMemoryMetrics
 
-`ProcessMemoryMetrics` reads process-level memory information from `/proc/self/smaps`.
+`ProcessMemoryMetrics` reads process-level memory information from `/proc/self/status`.
 All `Meter`s are reporting in `bytes`.
 
 > Please note that `procfs` is only available on Linux-based systems.
 
 * `process.memory.vss`: Virtual set size. The amount of virtual memory the process can access.
-  Mostly useles, but included for completeness sake.
+  Mostly irrelevant, but included for completeness sake.
 * `process.memory.rss`: Resident set size. The amount of process memory currently in RAM.
+* `process.memory.swap`: The amount of process memory paged out to swap.
+
+> Starting with `0.2.0` support for proportional set size metrics (`pss` and `swappss`) will
+> be dropped. The reasoning behind this is the overhead of processing the huge `/proc/self/smaps` file
+> which in turn imposes a CPU, memory and query duration overhead in bigger processes.
+> Instrumentation should be accurate and lightweight and the non-proportional set size metrics (`rss` and
+> `swap`) provide these properties as they are still the de-facto go-to information with regard to
+> memory utilization.
+
 * `process.memory.pss`: Proportional set size. The amount of process memory currently in RAM,
   accounting for shared pages among processes. This metric is the most accurate in
   terms of "real" memory usage.
-* `process.memory.swap`: The amount of process memory paged out to swap.
 * `process.memory.swappss`: The amount of process memory paged out to swap accounting for
   shared memory among processes. Since Linux 4.3. Will return `-1` if your
   kernel is older. As with `pss`, the most accurate metric to watch.

--- a/src/build/resources/pmd-ruleset.xml
+++ b/src/build/resources/pmd-ruleset.xml
@@ -47,6 +47,11 @@
         <exclude name="FieldNamingConventions" /> <!-- controversial exclusion -->
         <exclude name="AvoidFinalLocalVariable" />
     </rule>
+    <rule ref="category/java/codestyle.xml/ClassNamingConventions">
+        <properties>
+            <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]+(Utils?|Helper|Holder)" />
+        </properties>
+    </rule>
 
     <rule ref="category/java/design.xml">
         <exclude name="LoosePackageCoupling" />

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessMemoryMetrics.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessMemoryMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2019 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,36 +18,36 @@ package io.github.mweirauch.micrometer.jvm.extras;
 import java.util.Locale;
 import java.util.Objects;
 
-import io.github.mweirauch.micrometer.jvm.extras.procfs.ProcfsSmaps;
-import io.github.mweirauch.micrometer.jvm.extras.procfs.ProcfsSmaps.KEY;
+import io.github.mweirauch.micrometer.jvm.extras.procfs.ProcfsStatus;
+import io.github.mweirauch.micrometer.jvm.extras.procfs.ProcfsStatus.KEY;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
 public class ProcessMemoryMetrics implements MeterBinder {
 
-    private final ProcfsSmaps smaps;
+    private final ProcfsStatus status;
 
     public ProcessMemoryMetrics() {
-        this.smaps = new ProcfsSmaps();
+        this.status = ProcfsStatus.getInstance();
     }
 
-    /* default */ ProcessMemoryMetrics(ProcfsSmaps smaps) {
-        this.smaps = Objects.requireNonNull(smaps);
+    /* default */ ProcessMemoryMetrics(ProcfsStatus status) {
+        this.status = Objects.requireNonNull(status);
     }
 
     @Override
     public void bindTo(MeterRegistry registry) {
         for (final KEY key : KEY.values()) {
             final String name = "process.memory." + key.name().toLowerCase(Locale.ENGLISH);
-            Gauge.builder(name, smaps, smapsRef -> value(key))//
+            Gauge.builder(name, status, statusRef -> value(key))//
                     .baseUnit("bytes")//
                     .register(registry);
         }
     }
 
     private Double value(KEY key) {
-        return smaps.get(key);
+        return status.get(key);
     }
 
 }

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessThreadMetrics.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessThreadMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2019 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public class ProcessThreadMetrics implements MeterBinder {
     private final ProcfsStatus status;
 
     public ProcessThreadMetrics() {
-        this.status = new ProcfsStatus();
+        this.status = ProcfsStatus.getInstance();
     }
 
     /* default */ ProcessThreadMetrics(ProcfsStatus status) {

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/ProcessMemoryMetricsTest.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/ProcessMemoryMetricsTest.java
@@ -28,18 +28,18 @@ import org.junit.Test;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.NullPointerTester.Visibility;
 
-import io.github.mweirauch.micrometer.jvm.extras.procfs.ProcfsSmaps;
-import io.github.mweirauch.micrometer.jvm.extras.procfs.ProcfsSmaps.KEY;
+import io.github.mweirauch.micrometer.jvm.extras.procfs.ProcfsStatus;
+import io.github.mweirauch.micrometer.jvm.extras.procfs.ProcfsStatus.KEY;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public class ProcessMemoryMetricsTest {
 
-    private final ProcfsSmaps smaps = mock(ProcfsSmaps.class);
+    private final ProcfsStatus status = mock(ProcfsStatus.class);
 
     @Test
     public void testNullContract() {
-        final ProcessMemoryMetrics uut = new ProcessMemoryMetrics(smaps);
+        final ProcessMemoryMetrics uut = new ProcessMemoryMetrics(status);
 
         final NullPointerTester npt = new NullPointerTester();
 
@@ -56,14 +56,12 @@ public class ProcessMemoryMetricsTest {
 
     @Test
     public void testGetMetrics() throws Exception {
-        when(smaps.get(KEY.VSS)).thenReturn(1D);
-        when(smaps.get(KEY.RSS)).thenReturn(2D);
-        when(smaps.get(KEY.PSS)).thenReturn(3D);
-        when(smaps.get(KEY.SWAP)).thenReturn(4D);
-        when(smaps.get(KEY.SWAPPSS)).thenReturn(5D);
+        when(status.get(KEY.VSS)).thenReturn(1D);
+        when(status.get(KEY.RSS)).thenReturn(2D);
+        when(status.get(KEY.SWAP)).thenReturn(3D);
 
         final SimpleMeterRegistry registry = new SimpleMeterRegistry();
-        final ProcessMemoryMetrics uut = new ProcessMemoryMetrics(smaps);
+        final ProcessMemoryMetrics uut = new ProcessMemoryMetrics(status);
 
         uut.bindTo(registry);
 
@@ -77,20 +75,12 @@ public class ProcessMemoryMetricsTest {
         assertEquals(2.0, rss.value(), 0.0);
         assertEquals(expectedUnit, rss.getId().getBaseUnit());
 
-        final Gauge pss = registry.get("process.memory.pss").gauge();
-        assertEquals(3.0, pss.value(), 0.0);
-        assertEquals(expectedUnit, pss.getId().getBaseUnit());
-
         final Gauge swap = registry.get("process.memory.swap").gauge();
-        assertEquals(4.0, swap.value(), 0.0);
+        assertEquals(3.0, swap.value(), 0.0);
         assertEquals(expectedUnit, swap.getId().getBaseUnit());
 
-        final Gauge swappss = registry.get("process.memory.swappss").gauge();
-        assertEquals(5.0, swappss.value(), 0.0);
-        assertEquals(expectedUnit, swappss.getId().getBaseUnit());
-
-        verify(smaps, times(5)).get(any(KEY.class));
-        verifyNoMoreInteractions(smaps);
+        verify(status, times(3)).get(any(KEY.class));
+        verifyNoMoreInteractions(status);
     }
 
 }

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusTest.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusTest.java
@@ -16,6 +16,7 @@
 package io.github.mweirauch.micrometer.jvm.extras.procfs;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -53,10 +54,9 @@ public class ProcfsStatusTest {
         npt.testInstanceMethods(uut, Visibility.PACKAGE);
     }
 
-    @SuppressWarnings("unused")
     @Test
     public void testInstantiation() {
-        new ProcfsStatus();
+        assertSame(ProcfsStatus.getInstance(), ProcfsStatus.getInstance());
     }
 
     @Test
@@ -64,6 +64,9 @@ public class ProcfsStatusTest {
         final ProcfsStatus uut = new ProcfsStatus(new ProcfsReader(BASE, "status-001.txt"));
 
         assertEquals(Double.valueOf(55), uut.get(KEY.THREADS));
+        assertEquals(Double.valueOf(8678297600L), uut.get(KEY.VSS));
+        assertEquals(Double.valueOf(1031479296L), uut.get(KEY.RSS));
+        assertEquals(Double.valueOf(0), uut.get(KEY.SWAP));
     }
 
     @Test


### PR DESCRIPTION
These metrics provide the most accurate information with regard
to memory utilization but are quite expensive to collect.

The de-facto standard `rss` and `swap` metrics provide a more
than good-enough insight into the process memory usage.