### PR TITLE
Fix double registration of process threads

### DIFF
--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessMemoryMetrics.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessMemoryMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2021 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ public class ProcessMemoryMetrics implements MeterBinder {
     private final ProcfsStatus status;
 
     public ProcessMemoryMetrics() {
-        this.status = ProcfsStatus.getInstance();
+        this(ProcfsStatus.getInstance());
     }
 
     /* default */ ProcessMemoryMetrics(ProcfsStatus status) {
@@ -38,10 +38,11 @@ public class ProcessMemoryMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        for (final KEY key : KEY.values()) {
+        final KEY[] keys = { KEY.VSS, KEY.RSS, KEY.SWAP };
+        for (final KEY key : keys) {
             final String name = "process.memory." + key.name().toLowerCase(Locale.ENGLISH);
-            Gauge.builder(name, status, statusRef -> value(key))//
-                    .baseUnit("bytes")//
+            Gauge.builder(name, status, statusRef -> value(key)) //
+                    .baseUnit("bytes") //
                     .register(registry);
         }
     }

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessThreadMetrics.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessThreadMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2021 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public class ProcessThreadMetrics implements MeterBinder {
     private final ProcfsStatus status;
 
     public ProcessThreadMetrics() {
-        this.status = ProcfsStatus.getInstance();
+        this(ProcfsStatus.getInstance());
     }
 
     /* default */ ProcessThreadMetrics(ProcfsStatus status) {
@@ -37,8 +37,8 @@ public class ProcessThreadMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        Gauge.builder("process.threads", status, statusRef -> value(KEY.THREADS))//
-                .description("The number of process threads")//
+        Gauge.builder("process.threads", status, statusRef -> value(KEY.THREADS)) //
+                .description("The number of process threads") //
                 .register(registry);
     }
 

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/ProcessMemoryMetricsTest.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/ProcessMemoryMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2021 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,8 @@ public class ProcessMemoryMetricsTest {
 
         verify(status, times(3)).get(any(KEY.class));
         verifyNoMoreInteractions(status);
+
+        assertEquals(3, registry.getMeters().size());
     }
 
 }

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/ProcessThreadMetricsTest.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/ProcessThreadMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2021 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,8 @@ public class ProcessThreadMetricsTest {
         uut.bindTo(registry);
 
         assertEquals(7D, registry.get("process.threads").gauge().value(), 0.0);
+
+        assertEquals(1, registry.getMeters().size());
     }
 
 }


### PR DESCRIPTION
This was introduced with '0.2.0' when switching the memory metrics
retrieval to 'ProcfsStatus'.

Some cosmetics on the go.

Fixes #116.