### PR TITLE
Bump micrometer-core to 1.7.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     ignore:
       - dependency-name: io.micrometer:micrometer-core
         versions:
-          - ">= 1.2" # stick to oldest LTS
+          - ">= 1.8" # stick to oldest, oss-supported LTS version

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.1.19</version>
+            <version>1.7.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Baseline is now 1.7.x - currently the oldest, oss-supported LTS version.