### PR TITLE
Minimize lock contention on collecting metrics

### DIFF
--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsEntryTest.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsEntryTest.java
@@ -74,8 +74,8 @@ public class ProcfsEntryTest {
         assertEquals(Double.valueOf(2), spy.get(TestKey.TWO));
         assertEquals(Double.valueOf(-1), spy.get(TestKey.THREE));
 
-        // 5 for the checks and 2 for the update of the last handling time
-        verify(spy, times(7)).currentTime();
+        // 5 for the checks and 2 for the update of the last handling time + 1 because of double-checked locking
+        verify(spy, times(8)).currentTime();
         verify(reader, times(2)).read(any());
     }
 

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusBenchmark.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusBenchmark.java
@@ -15,6 +15,8 @@
  */
 package io.github.mweirauch.micrometer.jvm.extras.procfs;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
@@ -27,13 +29,15 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 public class ProcfsStatusBenchmark {
 
@@ -60,6 +64,23 @@ public class ProcfsStatusBenchmark {
     @BenchmarkMode(Mode.SingleShotTime)
     @Fork(value = 5, warmups = 0)
     public void collectSingle() {
+        uub.collect();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @Fork(value = 1, warmups = 0)
+    @Warmup(iterations = 3, time = 5, timeUnit = SECONDS)
+    public void collectAverage() {
+        uub.collect();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @Fork(value = 1, warmups = 0)
+    @Threads(4)
+    @Warmup(iterations = 3, time = 5, timeUnit = SECONDS)
+    public void collectAverageContended() {
         uub.collect();
     }
 


### PR DESCRIPTION
Double-checked locking was introduced in order to accelerate avoidance
of cache invalidation. Added benchmarks shows improvement in relative
numbers. At my machine it gives following results:
```
before
Benchmark                             Mode  Cnt   Score   Error  Units
ProcfsStatusBenchmark.collectAverage  avgt    5  48.140 ± 4.332  ns/op
after
Benchmark                             Mode  Cnt   Score   Error  Units
ProcfsStatusBenchmark.collectAverage  avgt    5  31.209 ± 0.689  ns/op
before
Benchmark                                     Mode  Cnt    Score   Error
ProcfsStatusBenchmark.collectAverageContended avgt    5  351.977 ± 9.126
                                                                   Units
                                                                   ns/op
after
Benchmark                                      Mode  Cnt   Score   Error
ProcfsStatusBenchmark.collectAverageContended  avgt    5  33.422 ± 2.751
                                                                   Units
                                                                   ns/op
```