### PR TITLE
Context switching metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ All `Meter`s are reporting in `bytes`.
 > Please note that `procfs` is only available on Linux-based systems.
 
 * `process.threads`: The number of process threads as seen by the operating system.
+* `process.threads.context.switches.voluntary`: The accumulated number of voluntary context switches since application start.
+  A voluntary context switch occurs when a thread is in a waiting or blocked state and the scheduler switches control to another
+  thread.
+* `process.threads.context.switches.nonvoluntary`: The accumulated number of non-voluntary context switches since application start.
+  An involuntary context switch occurs when a thread consumed the whole time slice it was granted from the scheduler. The thread is
+  suspended and control is switched to another thread.
 
 ## Notes
 

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessThreadMetrics.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/ProcessThreadMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2021 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2022 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.github.mweirauch.micrometer.jvm.extras;
 
+import io.micrometer.core.instrument.FunctionCounter;
 import java.util.Objects;
 
 import io.github.mweirauch.micrometer.jvm.extras.procfs.ProcfsStatus;
@@ -39,6 +40,16 @@ public class ProcessThreadMetrics implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         Gauge.builder("process.threads", status, statusRef -> value(KEY.THREADS)) //
                 .description("The number of process threads") //
+                .register(registry);
+
+        FunctionCounter.builder("process.threads.context.switches.voluntary", //
+                status, statusRef -> value(KEY.VOLUNTARY_CTXT_SWITCHES)) //
+                .description("Voluntary context switches") //
+                .register(registry);
+
+        FunctionCounter.builder("process.threads.context.switches.nonvoluntary", //
+                status, statusRef -> value(KEY.NONVOLUNTARY_CTXT_SWITCHES))//
+                .description("Non-voluntary context switches") //
                 .register(registry);
     }
 

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatus.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2022 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,15 @@ public class ProcfsStatus extends ProcfsEntry {
         /**
          * Paged out memory
          */
-        SWAP
+        SWAP,
+        /**
+         * Voluntary content switches
+         */
+        VOLUNTARY_CTXT_SWITCHES,
+        /**
+         * Non-voluntary context switches
+         */
+        NONVOLUNTARY_CTXT_SWITCHES
     }
 
     private static final Pattern VAL_LINE_PATTERN = Pattern.compile("^\\w+:\\s+(\\d+)$");
@@ -74,6 +82,10 @@ public class ProcfsStatus extends ProcfsEntry {
             values.put(KEY.RSS, parseKiloBytes(line) * KILOBYTE);
         } else if (line.startsWith("VmSwap:")) {
             values.put(KEY.SWAP, parseKiloBytes(line) * KILOBYTE);
+        } else if (line.startsWith("voluntary_ctxt_switches:")) {
+            values.put(KEY.VOLUNTARY_CTXT_SWITCHES, parseValue(line));
+        } else if (line.startsWith("nonvoluntary_ctxt_switches:")) {
+            values.put(KEY.NONVOLUNTARY_CTXT_SWITCHES, parseValue(line));
         }
     }
 

--- a/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusTest.java
+++ b/src/test/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Michael Weirauch (michael.weirauch@gmail.com)
+ * Copyright © 2017-2022 Michael Weirauch (michael.weirauch@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,8 @@ public class ProcfsStatusTest {
         assertEquals(Double.valueOf(8678297600L), uut.get(KEY.VSS));
         assertEquals(Double.valueOf(1031479296L), uut.get(KEY.RSS));
         assertEquals(Double.valueOf(0), uut.get(KEY.SWAP));
+        assertEquals(Double.valueOf(4), uut.get(KEY.VOLUNTARY_CTXT_SWITCHES));
+        assertEquals(Double.valueOf(1), uut.get(KEY.NONVOLUNTARY_CTXT_SWITCHES));
     }
 
     @Test


### PR DESCRIPTION
As of context switching can have a big impact of application performance
it would be nice to control how often it happens. Context switches are
generally slow operation taking about 100-1000 cycles of CPU and more
over after the switch we can observe CPU cache missing as the memory
cached for previous thread should be invalidated for the current one.
Measuring this value allow us to estimate overheads of using hundreds
of threads in classic blocking application or figure out that something
wrong happens in reactive application.