### PR TITLE
Replace synchronized block with ReentrantLock to avoid possible thread pinning with virtual threads (java 21)

### DIFF
--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsEntry.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsEntry.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,7 @@ abstract class ProcfsEntry {
 
     private static final long CACHE_DURATION_MS = 1000;
 
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
 
     private final ProcfsReader reader;
 
@@ -58,7 +59,8 @@ abstract class ProcfsEntry {
         if (lastHandle != -1 && lastHandle + CACHE_DURATION_MS > currentTime()) {
             return;
         }
-        synchronized (lock) {
+        try {
+            lock.lock();
             if (lastHandle != -1 && lastHandle + CACHE_DURATION_MS > currentTime()) {
                 return;
             }
@@ -73,6 +75,8 @@ abstract class ProcfsEntry {
                 values.clear();
                 log.warn("Failed reading '" + reader.getEntryPath() + "'!", e);
             }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsReader.java
+++ b/src/main/java/io/github/mweirauch/micrometer/jvm/extras/procfs/ProcfsReader.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 import org.slf4j.Logger;
@@ -35,7 +36,7 @@ class ProcfsReader {
 
     private static final Map<String, ProcfsReader> instances = new HashMap<>();
 
-    private static final Object instancesLock = new Object();
+    private static final ReentrantLock instancesLock = new ReentrantLock();
 
     private static final Path BASE = Paths.get("/proc", "self");
 
@@ -93,8 +94,11 @@ class ProcfsReader {
     /* default */ static ProcfsReader getInstance(String entry) {
         Objects.requireNonNull(entry);
 
-        synchronized (instancesLock) {
+        try {
+            instancesLock.lock();
             return instances.computeIfAbsent(entry, e -> new ProcfsReader(e));
+        } finally{
+            instancesLock.unlock();
         }
     }
 


### PR DESCRIPTION
It's recommended to avoid using synchronized block with VirtualThreads. Spring Boot starting from 3.2 and other frameworks now allow to run using virtual threads, so it's small, but valuable change for such scenarios.